### PR TITLE
Bug fix, CC & BCC support

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,20 +21,20 @@ var mailjet = new Mailjet('apiKey', 'secretKey');
 
 Sends a simple plain-text email.
 
-```
-sendText(from, to, subject, text)
+```javascript
+mailjet.sendText(from, to, subject, text);
 ```
 
 * from - Sender of the message; this should be a full email address (e.g. ```example@example.com```).
-* to - A string (example@example.com) or array of strings (['a@example.com', 'b@example.com']) of recipients.
+* to - A string (example@example.com) or array of strings (['a@example.com', 'b@example.com']) of recipients. For cc and bcc support, append cc: or bcc: to the recipient email address (cc:example@example.com).
 * subject - Message subject
 * text - Message body text
 
 ### Example
 
-```
-sendText(sender@example.com,
-         ['recipient1@example.com', 'recipient2@example.com'],
+```javascript
+mailjet.sendText(sender@example.com,
+         ['recipient1@example.com', 'bcc:recipient2@example.com'],
          'This is a test !',
          'Well, this is working !')
 ```

--- a/mail-parser.js
+++ b/mail-parser.js
@@ -7,8 +7,8 @@ exports.parse_recipient_type = function(recipient_list){
   }
   for(var i=0;i<recipient_list.length;++i){
     var parsed = recipient_list[i].split(':');
-    (parsed.length > 1) ? return_vals[parsed[0]]=parsed[1]
-      : return_vals['to'] = parsed[0];
+    (parsed.length > 1) ? return_vals[parsed[0]].push(parsed[1])
+      : return_vals['to'].push(parsed[0]);
   }
   return return_vals;
 }

--- a/mailjet.js
+++ b/mailjet.js
@@ -20,7 +20,7 @@ Mailjet.prototype.sendText = function(from, to, subject, text) {
 
   if (typeof(to) == 'string')
       to = [to];
-  var recipients = mail-parser.parse_recipient_type(to);
+  var recipients = mail_parser.parse_recipient_type(to);
   // Build the HTTP POST body text
   var body = querystring.stringify({
     from: from,


### PR DESCRIPTION
Add mail-parser.js file with support to send cc & bcc as well as to in the sendText() call by specifying cc: or bcc: at the front of the recipient email address.
